### PR TITLE
Bugfix: Take only time entries added before flexing into account when deriving the compensation rate.

### DIFF
--- a/AlvTime.Persistence/Repositories/TimeEntryStorage.cs
+++ b/AlvTime.Persistence/Repositories/TimeEntryStorage.cs
@@ -58,7 +58,7 @@ namespace AlvTime.Persistence.Repositories
                     {
                         TaskId = e.TaskId,
                         Value = e.Value,
-                        CompensationRate = compensationRates.FirstOrDefault(cr => cr.TaskId == e.TaskId).Value,
+                        CompensationRate = compensationRates.FirstOrDefault(cr => cr.TaskId == e.TaskId)?.Value ?? 1M,
                     })
                 });
         }

--- a/Tests/UnitTests/Flexihours/GetOvertimeEquivalentsTest.cs
+++ b/Tests/UnitTests/Flexihours/GetOvertimeEquivalentsTest.cs
@@ -237,6 +237,38 @@ namespace Tests.UnitTests.Flexihours
             Assert.Equal(5M, OTequivalents);
         }
 
+        [Fact]
+        public void GetOvertime_FlexingBeforeWorkingWithHighCompRate_WillNotSpendHighCompRateWhenFlexing()
+        {
+            _context.Hours.Add(CreateTimeEntry(date: new DateTime(2020, 01, 06), value: 8.5M, out int taskWithNormalCompensation));
+            _context.CompensationRate.Add(CreateCompensationRate(taskWithNormalCompensation, compRate: 1M));
+
+            _context.Hours.Add(CreateTimeEntry(date: new DateTime(2020, 01, 07), value: 6.5M, out int sometask));
+            _context.CompensationRate.Add(CreateCompensationRate(sometask, compRate: 1M));
+
+            _context.Hours.Add(new Hours
+            {
+                Date = new DateTime(2020, 01, 07),
+                Task = new Task
+                {
+                    Id = 18,
+                },
+                TaskId = 18,
+                User = 1,
+                Value = 1M
+            });
+
+            _context.Hours.Add(CreateTimeEntry(date: new DateTime(2020, 01, 08), value: 8.5M, out int taskWith5TimesCompensation));
+            _context.CompensationRate.Add(CreateCompensationRate(taskWith5TimesCompensation, compRate: 6M));
+
+            _context.SaveChanges();
+
+            FlexhourStorage calculator = CreateStorage();
+
+            var OTequivalents = calculator.GetOvertimeEquivalents(new DateTime(2020, 01, 06), new DateTime(2020, 01, 08), 1);
+            Assert.Equal(6M, OTequivalents);
+        }
+
         private FlexhourStorage CreateStorage()
         {
             return new FlexhourStorage(new TimeEntryStorage(_context), _context);


### PR DESCRIPTION
…exing is taken into account when deriving which compensation rate the flexing should 'spend'. Also defaulting compensation rate to 1 if not present in the database. Not sure if this is desired tho.